### PR TITLE
Add getPriceWithConditions and getPriceSumWithConditions in ItemColletion

### DIFF
--- a/src/Darryldecode/Cart/Cart.php
+++ b/src/Darryldecode/Cart/Cart.php
@@ -507,42 +507,7 @@ class Cart {
 
         $sum = $cart->sum(function($item)
         {
-            $originalPrice = $item->price;
-
-            $newPrice = 0.00;
-
-            $processed = 0;
-
-            if( $this->itemHasConditions($item) )
-            {
-                if( is_array($item->conditions) )
-                {
-                    foreach($item->conditions as $condition)
-                    {
-                        if( $condition->getTarget() === 'item' )
-                        {
-                            ( $processed > 0 ) ? $toBeCalculated = $newPrice : $toBeCalculated = $originalPrice;
-
-                            $newPrice = $condition->applyCondition($toBeCalculated);
-
-                            $processed++;
-                        }
-                    }
-                }
-                else
-                {
-                    if( $item['conditions']->getTarget() === 'item' )
-                    {
-                        $newPrice = $item['conditions']->applyCondition($originalPrice);
-                    }
-                }
-
-                return $newPrice * $item->quantity;
-            }
-            else
-            {
-                return $originalPrice * $item->quantity;
-            }
+            return $item->getPriceSumWithConditions();
         });
 
         return floatval($sum);

--- a/src/Darryldecode/Cart/ItemCollection.php
+++ b/src/Darryldecode/Cart/ItemCollection.php
@@ -27,6 +27,11 @@ class ItemCollection extends Collection {
         return null;
     }
 
+    /**
+     * check if item has confitions
+     *
+     * @return bool
+     */
     public function hasConditions()
     {
         if( ! isset($this['conditions']) ) return false;
@@ -40,6 +45,11 @@ class ItemCollection extends Collection {
         return false;
     }
 
+    /**
+     * get the single price in which conditions are already applied
+     *
+     * @return mixed|null
+     */
     public function getPriceWithConditions() 
     {
         $originalPrice = $this->price;
@@ -73,6 +83,11 @@ class ItemCollection extends Collection {
         return $originalPrice;
     }
 
+    /**
+     * get the sum of price in which conditions are already applied
+     *
+     * @return mixed|null
+     */
     public function getPriceSumWithConditions()
     {
         return $this->getPriceWithConditions() * $this->quantity;

--- a/src/Darryldecode/Cart/ItemCollection.php
+++ b/src/Darryldecode/Cart/ItemCollection.php
@@ -26,4 +26,55 @@ class ItemCollection extends Collection {
         if( $this->has($name) ) return $this->get($name);
         return null;
     }
+
+    public function hasConditions()
+    {
+        if( ! isset($this['conditions']) ) return false;
+        if( is_array($this['conditions']) )
+        {
+            return count($this['conditions']) > 0;
+        }
+        $conditionInstance = "Darryldecode\\Cart\\CartCondition";
+        if( $this['conditions'] instanceof $conditionInstance ) return true;
+
+        return false;
+    }
+
+    public function getPriceWithConditions() 
+    {
+        $originalPrice = $this->price;
+        $newPrice = 0.00;
+        $processed = 0;
+
+        if( $this->hasConditions() )
+        {
+            if( is_array($this->conditions) )
+            {
+                foreach($this->conditions as $condition)
+                {
+                    if( $condition->getTarget() === 'item' )
+                    {
+                        ( $processed > 0 ) ? $toBeCalculated = $newPrice : $toBeCalculated = $originalPrice;
+                        $newPrice = $condition->applyCondition($toBeCalculated);
+                        $processed++;
+                    }
+                }
+            }
+            else
+            {
+                if( $this['conditions']->getTarget() === 'item' )
+                {
+                    $newPrice = $this['conditions']->applyCondition($originalPrice);
+                }
+            }
+
+            return $newPrice;
+        }
+        return $originalPrice;
+    }
+
+    public function getPriceSumWithConditions()
+    {
+        return $this->getPriceWithConditions() * $this->quantity;
+    }
 }

--- a/tests/CartConditionsTest.php
+++ b/tests/CartConditionsTest.php
@@ -242,6 +242,7 @@ class CartConditionTest extends PHPUnit_Framework_TestCase  {
 
         $this->cart->add($item);
 
+        $this->assertEquals(95, $this->cart->get(456)->getPriceSumWithConditions());
         $this->assertEquals(95, $this->cart->getSubTotal());
     }
 
@@ -277,7 +278,8 @@ class CartConditionTest extends PHPUnit_Framework_TestCase  {
 
         $this->cart->add($item);
 
-        $this->assertEquals(80.00, $this->cart->getSubTotal(), 'Cart subtotal with 1 item should be 70');
+        $this->assertEquals(80.00, $this->cart->get(456)->getPriceSumWithConditions(), 'Item subtotal with 1 item should be 80');
+        $this->assertEquals(80.00, $this->cart->getSubTotal(), 'Cart subtotal with 1 item should be 80');
     }
 
     public function test_add_item_with_multiple_item_conditions_with_one_condition_wrong_target()
@@ -324,7 +326,8 @@ class CartConditionTest extends PHPUnit_Framework_TestCase  {
 
         $this->cart->add($item);
 
-        $this->assertEquals(85.00, $this->cart->getSubTotal(), 'Cart subtotal with 1 item should be 70');
+        $this->assertEquals(85.00, $this->cart->get(456)->getPriceSumWithConditions(), 'Cart subtotal with 1 item should be 85');
+        $this->assertEquals(85.00, $this->cart->getSubTotal(), 'Cart subtotal with 1 item should be 85');
     }
 
     public function test_add_item_condition()


### PR DESCRIPTION
In my cart I need to show price per row in which conditions are already applied.
Each ItemCollection has a method getPriceWithConditions and getPriceSumWithConditions.
Cart use getPriceSumWithConditions to calculate subtotal. 
These commits resolve #33.