### PR TITLE
Order conditions

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,15 +310,20 @@ $condition1 = new \Darryldecode\Cart\CartCondition(array(
     'type' => 'tax',
     'target' => 'subtotal',
     'value' => '12.5%',
+    'order' => 2
 ));
 $condition2 = new \Darryldecode\Cart\CartCondition(array(
     'name' => 'Express Shipping $15',
     'type' => 'shipping',
     'target' => 'subtotal',
     'value' => '+15',
+    'order' => 1
 ));
 Cart::condition($condition1);
 Cart::condition($condition2);
+
+// The property 'Order' lets you add different conditions through for example a shopping process with multiple
+// pages and still be able to set an order to apply the conditions. If no order is defined defaults to 0 
 
 // or add multiple conditions as array
 Cart::condition([$condition1, $condition2]);
@@ -331,6 +336,7 @@ foreach($carConditions as $condition)
     $condition->getName(); // the name of the condition
     $condition->getType(); // the type
     $condition->getValue(); // the value of the condition
+    $condition->getOrder(); // the order of the condition
     $condition->getAttributes(); // the attributes of the condition, returns an empty [] if no attributes added
 }
 

--- a/src/Darryldecode/Cart/Cart.php
+++ b/src/Darryldecode/Cart/Cart.php
@@ -334,6 +334,12 @@ class Cart {
 
         $conditions = $this->getConditions();
 
+        // Check if order has been applied
+        if($condition->getOrder() == 0) {
+            $last = $conditions->last();
+            $condition->setOrder(!is_null($last) ? $last->getOrder() + 1 : 1);
+        }
+
         $conditions->put($condition->getName(), $condition);
 
         $conditions = $conditions->sortBy(function ($condition, $key) {

--- a/src/Darryldecode/Cart/Cart.php
+++ b/src/Darryldecode/Cart/Cart.php
@@ -336,6 +336,10 @@ class Cart {
 
         $conditions->put($condition->getName(), $condition);
 
+        $conditions = $conditions->sortBy(function ($condition, $key) {
+            return $condition->getOrder();
+        });
+
         $this->saveConditions($conditions);
 
         return $this;

--- a/src/Darryldecode/Cart/CartCondition.php
+++ b/src/Darryldecode/Cart/CartCondition.php
@@ -93,7 +93,19 @@ class CartCondition {
     }
 
     /**
-     * the order to apply this condition. If no argument order is applied defaults to 0
+     * Set the order to apply this condition. If no argument order is applied we return 0 as
+     * indicator that no assignment has been made
+     * @param int $order
+     * @return Integer
+     */
+    public function setOrder($order = 1)
+    {
+        $this->args['order'] = $order;
+    }
+
+    /**
+     * the order to apply this condition. If no argument order is applied we return 0 as
+     * indicator that no assignment has been made
      *
      * @return Integer
      */

--- a/src/Darryldecode/Cart/CartCondition.php
+++ b/src/Darryldecode/Cart/CartCondition.php
@@ -93,6 +93,16 @@ class CartCondition {
     }
 
     /**
+     * the order to apply this condition. If no argument order is applied defaults to 0
+     *
+     * @return Integer
+     */
+    public function getOrder()
+    {
+        return isset($this->args['order']) && is_numeric($this->args['order']) ? (int)$this->args['order'] : 0;
+    }
+
+    /**
      * apply condition to total or subtotal
      *
      * @param $totalOrSubTotalOrPrice

--- a/tests/CartConditionsTest.php
+++ b/tests/CartConditionsTest.php
@@ -813,6 +813,46 @@ class CartConditionTest extends PHPUnit_Framework_TestCase  {
         $this->assertEquals('2015-01-30',$conditionAttributes['sale_end_date']);
     }
 
+    public function test_get_order_from_condition()
+    {
+        $cartCondition1 = new CartCondition(array(
+            'name' => 'SALE 5%',
+            'type' => 'sale',
+            'target' => 'subtotal',
+            'value' => '-5%',
+            'order' => 2
+        ));
+        $cartCondition2 = new CartCondition(array(
+            'name' => 'Item Gift Pack 20',
+            'type' => 'promo',
+            'target' => 'subtotal',
+            'value' => '-25',
+            'order' => '3'
+        ));
+        $cartCondition3 = new CartCondition(array(
+            'name' => 'Item Less 8%',
+            'type' => 'tax',
+            'target' => 'subtotal',
+            'value' => '-8%',
+            'order' => 'first'
+        ));
+
+        $this->assertEquals(2, $cartCondition1->getOrder());
+        $this->assertEquals(3, $cartCondition2->getOrder()); // numeric string is converted to integer
+        $this->assertEquals(0, $cartCondition3->getOrder()); // no numeric string is converted to 0
+
+        $this->cart->condition($cartCondition1);
+        $this->cart->condition($cartCondition2);
+        $this->cart->condition($cartCondition3);
+
+        $conditions = $this->cart->getConditions();
+
+        $this->assertEquals('tax', $conditions->shift()->getType());
+        $this->assertEquals('sale', $conditions->shift()->getType());
+        $this->assertEquals('promo', $conditions->shift()->getType());
+
+    }
+
     protected function fillCart()
     {
         $items = array(

--- a/tests/CartConditionsTest.php
+++ b/tests/CartConditionsTest.php
@@ -847,9 +847,9 @@ class CartConditionTest extends PHPUnit_Framework_TestCase  {
 
         $conditions = $this->cart->getConditions();
 
-        $this->assertEquals('tax', $conditions->shift()->getType());
         $this->assertEquals('sale', $conditions->shift()->getType());
         $this->assertEquals('promo', $conditions->shift()->getType());
+        $this->assertEquals('tax', $conditions->shift()->getType());
 
     }
 


### PR DESCRIPTION
Allowing to order conditions applied at different stages of the shopping cart. Added new property 'order' default to 0 and sorting ASC by this value.