### PR TITLE
Changing share to singleton

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,9 +11,9 @@
     ],
     "require": {
         "php": ">=5.4.0",
-        "illuminate/support": "5.0.*|5.1.*|5.2.*|5.3.*",
-        "illuminate/validation": "5.0.*|5.1.*|5.2.*|5.3.*",
-        "illuminate/translation": "5.0.*|5.1.*|5.2.*|5.3.*"
+        "illuminate/support": "5.0.*|5.1.*|5.2.*|5.3.*|5.4.*",
+        "illuminate/validation": "5.0.*|5.1.*|5.2.*|5.3.*|5.4.*",
+        "illuminate/translation": "5.0.*|5.1.*|5.2.*|5.3.*|5.4.*"
     },
     "require-dev": {
         "mockery/mockery": "~0.9",

--- a/src/Darryldecode/Cart/CartServiceProvider.php
+++ b/src/Darryldecode/Cart/CartServiceProvider.php
@@ -32,7 +32,7 @@ class CartServiceProvider extends ServiceProvider {
 	{
 		$this->mergeConfigFrom(__DIR__.'/config/config.php', 'shopping_cart');
 
-		$this->app['cart'] = $this->app->share(function($app)
+		$this->app->singleton('cart', function($app)
 		{
 			$storage = $app['session'];
 			$events = $app['events'];


### PR DESCRIPTION
With Laravel 5.4 the share method has been deprecated so we have to change it using the singleton method.