### PR TITLE
Associating cart items with a Model

### DIFF
--- a/src/Darryldecode/Cart/Cart.php
+++ b/src/Darryldecode/Cart/Cart.php
@@ -194,41 +194,46 @@ class Cart
 
         $cart = $this->getContent();
 
-        $item = $cart->pull($id);
+        $cart->transform(function($item, $key) use ($id, $data) {
 
-        foreach ($data as $key => $value) {
-            // if the key is currently "quantity" we will need to check if an arithmetic
-            // symbol is present so we can decide if the update of quantity is being added
-            // or being reduced.
-            if ($key == 'quantity') {
-                // we will check if quantity value provided is array,
-                // if it is, we will need to check if a key "relative" is set
-                // and we will evaluate its value if true or false,
-                // this tells us how to treat the quantity value if it should be updated
-                // relatively to its current quantity value or just totally replace the value
-                if (is_array($value)) {
-                    if (isset($value['relative'])) {
-                        if ((bool)$value['relative']) {
-                            $item = $this->updateQuantityRelative($item, $key, $value['value']);
+            if($key === $id){
+
+                foreach ($data as $key => $value) {
+                    // if the key is currently "quantity" we will need to check if an arithmetic
+                    // symbol is present so we can decide if the update of quantity is being added
+                    // or being reduced.
+                    if ($key == 'quantity') {
+                        // we will check if quantity value provided is array,
+                        // if it is, we will need to check if a key "relative" is set
+                        // and we will evaluate its value if true or false,
+                        // this tells us how to treat the quantity value if it should be updated
+                        // relatively to its current quantity value or just totally replace the value
+                        if (is_array($value)) {
+                            if (isset($value['relative'])) {
+                                if ((bool)$value['relative']) {
+                                    $item = $this->updateQuantityRelative($item, $key, $value['value']);
+                                } else {
+                                    $item = $this->updateQuantityNotRelative($item, $key, $value['value']);
+                                }
+                            }
                         } else {
-                            $item = $this->updateQuantityNotRelative($item, $key, $value['value']);
+                            $item = $this->updateQuantityRelative($item, $key, $value);
                         }
+                    } elseif ($key == 'attributes') {
+                        $item[$key] = new ItemAttributeCollection($value);
+                    } else {
+                        $item[$key] = $value;
                     }
-                } else {
-                    $item = $this->updateQuantityRelative($item, $key, $value);
                 }
-            } elseif ($key == 'attributes') {
-                $item[$key] = new ItemAttributeCollection($value);
-            } else {
-                $item[$key] = $value;
             }
-        }
 
-        $cart->put($id, $item);
+            return $item;
+
+        });
 
         $this->save($cart);
 
-        $this->fireEvent('updated', $item);
+        $this->fireEvent('updated', $cart->get($id));
         return true;
     }
 

--- a/src/Darryldecode/Cart/CartCollection.php
+++ b/src/Darryldecode/Cart/CartCollection.php
@@ -4,4 +4,16 @@ use Illuminate\Support\Collection;
 
 class CartCollection extends Collection {
 
+    public function associate($model, $field = 'id'){
+
+        $associated = new $model;
+
+        $this->transform(function($item, $key) use ($associated, $field) {
+            $item['association'] = $associated->where($field,$key)->first();
+            return $item;
+        });
+
+        return $this;
+    }
+
 }


### PR DESCRIPTION
The new method associate() on the CartCollection class would associate all the items in the cart with a specific model, appending the key 'association' containing all data provided by the model.

For example, suppose you want to associate the items in the cart with the model Product of your app.
So, you could just use:

\Cart::getContents()->associate('App\Product')->toJson()

If the ID of the items in the cart corresponds to another field on the Model (different from 'id', such as 'sku' or any other unique column field), you can inform it in the second parameter, like so:

\Cart::getContents()->associate('App\Product', 'sku')->toJson()