### PR TITLE
Normalize Price takes number formatting into account

### DIFF
--- a/src/Darryldecode/Cart/Cart.php
+++ b/src/Darryldecode/Cart/Cart.php
@@ -180,7 +180,7 @@ class Cart
         $item = $this->validate(array(
             'id' => $id,
             'name' => $name,
-            'price' => Helpers::normalizePrice($price),
+            'price' => Helpers::normalizePrice($price, $this->config),
             'quantity' => $quantity,
             'attributes' => new ItemAttributeCollection($attributes),
             'conditions' => $conditions,

--- a/src/Darryldecode/Cart/CartCondition.php
+++ b/src/Darryldecode/Cart/CartCondition.php
@@ -24,6 +24,8 @@ class CartCondition {
      */
     private $parsedRawValue;
 
+    private $config;
+
     /**
      * @param array $args (name, type, target, value)
      * @throws InvalidConditionException
@@ -40,6 +42,8 @@ class CartCondition {
         {
             $this->validate($this->args);
         }
+
+        $this->config = config('shopping_cart');
     }
 
     /**
@@ -139,6 +143,18 @@ class CartCondition {
     }
 
     /**
+     * get the calculated value of this condition supplied by the subtotal|price
+     *
+     * @param $totalOrSubTotalOrPrice
+     * @return mixed
+     */
+    public function getCalculatedValueFormatted($totalOrSubTotalOrPrice)
+    {
+        $value = $this->getCalculatedValue($totalOrSubTotalOrPrice);
+        return Helpers::formatValue($value, $this->config['format_numbers'], $this->config);
+    }
+
+    /**
      * apply condition
      *
      * @param $totalOrSubTotalOrPrice
@@ -147,6 +163,7 @@ class CartCondition {
      */
     protected function apply($totalOrSubTotalOrPrice, $conditionValue)
     {
+        $totalOrSubTotalOrPrice = Helpers::normalizePrice( $totalOrSubTotalOrPrice, $this->getConfig() );
         // if value has a percentage sign on it, we will get first
         // its percentage then we will evaluate again if the value
         // has a minus or plus sign so we can decide what to do with the
@@ -156,7 +173,7 @@ class CartCondition {
         {
             if( $this->valueIsToBeSubtracted($conditionValue) )
             {
-                $value = Helpers::normalizePrice( $this->cleanValue($conditionValue) );
+                $value = Helpers::normalizePrice( $this->cleanValue($conditionValue), $this->getConfig() );
 
                 $this->parsedRawValue = $totalOrSubTotalOrPrice * ($value / 100);
 
@@ -164,7 +181,7 @@ class CartCondition {
             }
             else if ( $this->valueIsToBeAdded($conditionValue) )
             {
-                $value = Helpers::normalizePrice( $this->cleanValue($conditionValue) );
+                $value = Helpers::normalizePrice( $this->cleanValue($conditionValue), $this->getConfig() );
 
                 $this->parsedRawValue = $totalOrSubTotalOrPrice * ($value / 100);
 
@@ -172,8 +189,8 @@ class CartCondition {
             }
             else
             {
-                $value = Helpers::normalizePrice($conditionValue);
-
+                $value = Helpers::normalizePrice($conditionValue, $this->getConfig());
+                
                 $this->parsedRawValue = $totalOrSubTotalOrPrice * ($value / 100);
 
                 $result = floatval($totalOrSubTotalOrPrice + $this->parsedRawValue);
@@ -186,19 +203,19 @@ class CartCondition {
         {
             if( $this->valueIsToBeSubtracted($conditionValue) )
             {
-                $this->parsedRawValue = Helpers::normalizePrice( $this->cleanValue($conditionValue) );
+                $this->parsedRawValue = Helpers::normalizePrice( $this->cleanValue($conditionValue), $this->getConfig() );
 
                 $result = floatval($totalOrSubTotalOrPrice - $this->parsedRawValue);
             }
             else if ( $this->valueIsToBeAdded($conditionValue) )
             {
-                $this->parsedRawValue = Helpers::normalizePrice( $this->cleanValue($conditionValue) );
+                $this->parsedRawValue = Helpers::normalizePrice( $this->cleanValue($conditionValue), $this->getConfig() );
 
                 $result = floatval($totalOrSubTotalOrPrice + $this->parsedRawValue);
             }
             else
             {
-                $this->parsedRawValue = Helpers::normalizePrice($conditionValue);
+                $this->parsedRawValue = Helpers::normalizePrice($conditionValue, $this->getConfig());
 
                 $result = floatval($totalOrSubTotalOrPrice + $this->parsedRawValue);
             }
@@ -215,7 +232,7 @@ class CartCondition {
      * @return bool
      */
     protected function valueIsPercentage($value)
-    {
+    { 
         return (preg_match('/%/', $value) == 1);
     }
 
@@ -273,5 +290,14 @@ class CartCondition {
         {
             throw new InvalidConditionException($validator->messages()->first());
         }
+    }
+
+    protected function getConfig()
+    {
+        if ($this->config == null) {
+            $this->config = config('shopping_cart');
+        }
+
+        return $this->config;
     }
 }

--- a/src/Darryldecode/Cart/Helpers/Helpers.php
+++ b/src/Darryldecode/Cart/Helpers/Helpers.php
@@ -15,9 +15,21 @@ class Helpers {
      * @param $price
      * @return float
      */
-    public static function normalizePrice($price)
+    public static function normalizePrice($price, $config = null)
     {
-        return (is_string($price)) ? floatval($price) : $price;
+        if (!is_string($price)) {
+             return $price;
+        }
+
+        if ($config != null && $config['format_numbers']) {
+            $normalized = str_replace($config['dec_point'], '[dec_point]', 
+                str_replace($config['thousands_sep'], '[thousands_sep]', $price));
+
+            $price = str_replace('[dec_point]', '.',
+                str_replace('[thousands_sep]', '', $normalized));
+        }
+        
+        return floatval($price);
     }
 
     /**

--- a/src/Darryldecode/Cart/ItemCollection.php
+++ b/src/Darryldecode/Cart/ItemCollection.php
@@ -74,7 +74,18 @@ class ItemCollection extends Collection {
     public function getConditions()
     {
         if(! $this->hasConditions() ) return [];
-        return $this['conditions'];
+        return new ItemConditionCollection($this['conditions']);
+    }
+
+    /**
+     * get condition applied on the item by its name
+     *
+     * @param $conditionName
+     * @return CartCondition
+     */
+    public function getCondition($conditionName)
+    {
+        return $this->getConditions()->first(function($c) use ($conditionName) {return $c->getName() == $conditionName;});
     }
 
     /**

--- a/src/Darryldecode/Cart/ItemConditionCollection.php
+++ b/src/Darryldecode/Cart/ItemConditionCollection.php
@@ -1,0 +1,14 @@
+<?php namespace Darryldecode\Cart;
+
+/**
+ * Created by PhpStorm.
+ * User: jonowat
+ * Date: 1/3/2018
+ * Time: 9:46 PM
+ */
+
+use Illuminate\Support\Collection;
+
+class ItemConditionCollection extends Collection {
+
+}


### PR DESCRIPTION
When loading a serialised object back into the Cart, if the prices have been formatted according to the config settings, the string values need to be converted to the decimal format expected by php.

NormalizePrice can take the config object and do this transform when appropriate before parse_float.