### PR TITLE
Merge for version 4.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,10 @@
 language: php
 
 php:
-  - 5.5
   - 5.6
   - 7.0
+  - 7.1
+  - 7.2
 
 before_script:
   - travis_retry composer self-update

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: php
 
 php:
-  - 5.4
   - 5.5
   - 5.6
+  - 7.0
 
 before_script:
   - travis_retry composer self-update

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ For Laravel 5.1~:
 ```composer require "darryldecode/cart:~2.0"```
     
 For Laravel 5.5 or 5.6~:
-```composer require "darryldecode/cart:~3.0"```
+```composer require "darryldecode/cart:~4.0"```
 
 ## CONFIGURATION
 
@@ -349,7 +349,8 @@ If the target is "subtotal" then this condition will be applied to subtotal.
 If the target is "total" then this condition will be applied to total.
 The order of operation also during calculation will vary on the order you have added the conditions.
 
-Also, when adding conditions, the 'value' field will be the bases of calculation.
+Also, when adding conditions, the 'value' field will be the bases of calculation. You can change this order
+by adding 'order' parameter in CartCondition.
 
 ```php
 
@@ -395,13 +396,14 @@ $condition = new \Darryldecode\Cart\CartCondition(array(
     'type' => 'shipping',
     'target' => 'total', // this condition will be applied to cart's total when getTotal() is called.
     'value' => '+15',
-    'order' => 1
+    'order' => 1 // the order of calculation of cart base conditions. The bigger the later to be applied.
 ));
 Cart::condition($condition);
 
-
-// The property 'order' lets you add different conditions through for example a shopping process with multiple
+// The property 'order' lets you control the sequence of conditions when calculated. Also it lets you add different conditions through for example a shopping process with multiple
 // pages and still be able to set an order to apply the conditions. If no order is defined defaults to 0 
+
+// NOTE!! On current version, 'order' parameter is only applicable for conditions for cart bases. It does not support on per item conditions.
 
 // or add multiple conditions as array
 Cart::condition([$condition1, $condition2]);
@@ -503,7 +505,7 @@ $item = array(
 Cart::add($item);
 ```
 
-> NOTE: All cart per-item conditions should be applied before calling **Cart::getSubTotal()**
+> NOTE: All cart per-item conditions should be added before calling **Cart::getSubTotal()**
 
 Then Finally you can call **Cart::getSubTotal()** to get the Cart sub total with the applied conditions on each of the items.
 ```php

--- a/README.md
+++ b/README.md
@@ -344,8 +344,9 @@ First let's add a condition on a Cart Bases:
 There are also several ways of adding a condition on a cart:
 NOTE:
 
-When adding a condition on a cart bases, the 'target' should have value of 'subtotal'.
-And when adding a condition on an item, the 'target' should be 'item'.
+When adding a condition on a cart bases, the 'target' should have value of 'subtotal' or 'total'.
+If the target is "subtotal" then this condition will be applied to subtotal.
+If the target is "total" then this condition will be applied to total.
 The order of operation also during calculation will vary on the order you have added the conditions.
 
 Also, when adding conditions, the 'value' field will be the bases of calculation.
@@ -356,7 +357,7 @@ Also, when adding conditions, the 'value' field will be the bases of calculation
 $condition = new \Darryldecode\Cart\CartCondition(array(
     'name' => 'VAT 12.5%',
     'type' => 'tax',
-    'target' => 'subtotal',
+    'target' => 'subtotal', // this condition will be applied to cart's subtotal when getSubTotal() is called.
     'value' => '12.5%',
     'attributes' => array( // attributes field is optional
     	'description' => 'Value added tax',
@@ -371,21 +372,35 @@ Cart::session($userId)->condition($condition); // for a speicifc user's cart
 $condition1 = new \Darryldecode\Cart\CartCondition(array(
     'name' => 'VAT 12.5%',
     'type' => 'tax',
-    'target' => 'subtotal',
+    'target' => 'subtotal', // this condition will be applied to cart's subtotal when getSubTotal() is called.
     'value' => '12.5%',
     'order' => 2
 ));
 $condition2 = new \Darryldecode\Cart\CartCondition(array(
     'name' => 'Express Shipping $15',
     'type' => 'shipping',
-    'target' => 'subtotal',
+    'target' => 'subtotal', // this condition will be applied to cart's subtotal when getSubTotal() is called.
     'value' => '+15',
     'order' => 1
 ));
 Cart::condition($condition1);
 Cart::condition($condition2);
 
-// The property 'Order' lets you add different conditions through for example a shopping process with multiple
+// Note that after adding conditions that are targeted to be applied on subtotal, the result on getTotal()
+// will also be affected as getTotal() depends in getSubTotal() which is the subtotal.
+
+// add condition to only apply on totals, not in subtotal
+$condition = new \Darryldecode\Cart\CartCondition(array(
+    'name' => 'Express Shipping $15',
+    'type' => 'shipping',
+    'target' => 'total', // this condition will be applied to cart's total when getTotal() is called.
+    'value' => '+15',
+    'order' => 1
+));
+Cart::condition($condition);
+
+
+// The property 'order' lets you add different conditions through for example a shopping process with multiple
 // pages and still be able to set an order to apply the conditions. If no order is defined defaults to 0 
 
 // or add multiple conditions as array
@@ -417,11 +432,14 @@ $condition = Cart::getCondition('VAT 12.5%');
 $conditionCalculatedValue = $condition->getCalculatedValue($subTotal);
 ```
 
-NOTE: All cart based conditions should be applied before calling **Cart::getTotal()**
+> NOTE: All cart based conditions should be added to cart's conditions before calling **Cart::getTotal()**
+and if there are also conditions that are targeted to be applied to subtotal, it should be added to cart's conditions
+before calling **Cart::getSubTotal()**
 
-Then Finally you can call **Cart::getTotal()** to get the Cart Total with the applied conditions.
 ```php
-$cartTotal = Cart::getTotal(); // the total will be calculated based on the conditions you ave provided
+$cartTotal = Cart::getSubTotal(); // the subtotal with the conditions targeted to "subtotal" applied
+$cartTotal = Cart::getTotal(); // the total with the conditions targeted to "total" applied
+$cartTotal = Cart::session($userId)->getSubTotal(); // for a specific user's cart
 $cartTotal = Cart::session($userId)->getTotal(); // for a specific user's cart
 ```
 
@@ -429,7 +447,8 @@ Next is the Condition on Per-Item Bases.
 
 This is very useful if you have coupons to be applied specifically on an item and not on the whole cart value.
 
-NOTE: When adding a condition on a per-item bases, the 'target' should have value of 'item'.
+> NOTE: When adding a condition on a per-item bases, the 'target' parameter is not needed or can be omitted.
+unlike when adding conditions or per cart bases.
 
 Now let's add condition on an item.
 
@@ -439,7 +458,6 @@ Now let's add condition on an item.
 $saleCondition = new \Darryldecode\Cart\CartCondition(array(
             'name' => 'SALE 5%',
             'type' => 'tax',
-            'target' => 'item',
             'value' => '-5%',
         ));
 
@@ -460,19 +478,16 @@ Cart::add($product);
 $itemCondition1 = new \Darryldecode\Cart\CartCondition(array(
     'name' => 'SALE 5%',
     'type' => 'sale',
-    'target' => 'item',
     'value' => '-5%',
 ));
 $itemCondition2 = new CartCondition(array(
     'name' => 'Item Gift Pack 25.00',
     'type' => 'promo',
-    'target' => 'item',
     'value' => '-25',
 ));
 $itemCondition3 = new \Darryldecode\Cart\CartCondition(array(
     'name' => 'MISC',
     'type' => 'misc',
-    'target' => 'item',
     'value' => '+10',
 ));
 
@@ -488,14 +503,16 @@ $item = array(
 Cart::add($item);
 ```
 
-NOTE: All cart per-item conditions should be applied before calling **Cart::getSubTotal()**
+> NOTE: All cart per-item conditions should be applied before calling **Cart::getSubTotal()**
 
-Then Finally you can call **Cart::getSubTotal()** to get the Cart sub total with the applied conditions.
+Then Finally you can call **Cart::getSubTotal()** to get the Cart sub total with the applied conditions on each of the items.
 ```php
-$cartSubTotal = Cart::getSubTotal(); // the subtotal will be calculated based on the conditions you have provided
+// the subtotal will be calculated based on the conditions added that has target => "subtotal"
+// and also conditions that are added on per item
+$cartSubTotal = Cart::getSubTotal();
 ```
 
-Add condition to exisiting Item on the cart: **Cart::addItemCondition($productId, $itemCondition)**
+Add condition to existing Item on the cart: **Cart::addItemCondition($productId, $itemCondition)**
 
 Adding Condition to an existing Item on the cart is simple as well.
 
@@ -507,7 +524,6 @@ $productID = 456;
 $coupon101 = new CartCondition(array(
             'name' => 'COUPON 101',
             'type' => 'coupon',
-            'target' => 'item',
             'value' => '-5%',
         ));
 

--- a/composer.json
+++ b/composer.json
@@ -16,8 +16,8 @@
         "illuminate/translation": "5.0.*|5.1.*|5.2.*|5.3.*|5.4.*|5.5.*|5.6.*"
     },
     "require-dev": {
-        "mockery/mockery": "~0.9",
-        "phpunit/phpunit": "~4.0",
+        "mockery/mockery": "^1.0",
+        "phpunit/phpunit": "^7.0",
         "symfony/var-dumper": "2.7.*@dev"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     },
     "require-dev": {
         "mockery/mockery": "^1.0",
-        "phpunit/phpunit": "^7.0",
+        "phpunit/phpunit": "^5.0",
         "symfony/var-dumper": "2.7.*@dev"
     },
     "autoload": {

--- a/src/Darryldecode/Cart/CartCondition.php
+++ b/src/Darryldecode/Cart/CartCondition.php
@@ -43,13 +43,14 @@ class CartCondition {
     }
 
     /**
-     * the target of where the condition is applied
+     * the target of where the condition is applied.
+     * NOTE: On conditions added to per item bases, target is not needed.
      *
      * @return mixed
      */
     public function getTarget()
     {
-        return $this->args['target'];
+        return (isset($this->args['target'])) ? $this->args['target'] : '';
     }
 
     /**
@@ -263,7 +264,6 @@ class CartCondition {
         $rules = array(
             'name' => 'required',
             'type' => 'required',
-            'target' => 'required',
             'value' => 'required',
         );
 

--- a/src/Darryldecode/Cart/ItemCollection.php
+++ b/src/Darryldecode/Cart/ItemCollection.php
@@ -94,20 +94,14 @@ class ItemCollection extends Collection {
             {
                 foreach($this->conditions as $condition)
                 {
-                    if( $condition->getTarget() === 'item' )
-                    {
-                        ( $processed > 0 ) ? $toBeCalculated = $newPrice : $toBeCalculated = $originalPrice;
-                        $newPrice = $condition->applyCondition($toBeCalculated);
-                        $processed++;
-                    }
+                    ( $processed > 0 ) ? $toBeCalculated = $newPrice : $toBeCalculated = $originalPrice;
+                    $newPrice = $condition->applyCondition($toBeCalculated);
+                    $processed++;
                 }
             }
             else
             {
-                if( $this['conditions']->getTarget() === 'item' )
-                {
-                    $newPrice = $this['conditions']->applyCondition($originalPrice);
-                }
+                $newPrice = $this['conditions']->applyCondition($originalPrice);
             }
 
             return Helpers::formatValue($newPrice, $formatted, $this->config);

--- a/tests/CartConditionsTest.php
+++ b/tests/CartConditionsTest.php
@@ -12,7 +12,7 @@ use Mockery as m;
 
 require_once __DIR__.'/helpers/SessionMock.php';
 
-class CartConditionTest extends PHPUnit_Framework_TestCase  {
+class CartConditionTest extends PHPUnit\Framework\TestCase  {
 
     /**
      * @var Darryldecode\Cart\Cart
@@ -38,6 +38,27 @@ class CartConditionTest extends PHPUnit_Framework_TestCase  {
         m::close();
     }
 
+    public function test_subtotal()
+    {
+        $this->fillCart();
+
+        // add condition to subtotal
+        $condition = new CartCondition(array(
+            'name' => 'VAT 12.5%',
+            'type' => 'tax',
+            'target' => 'subtotal',
+            'value' => '-5',
+        ));
+
+        $this->cart->condition($condition);
+
+        $this->assertEquals(182.49,$this->cart->getSubTotal());
+
+        // the total is also should be the same with sub total since our getTotal
+        // also depends on what is the value of subtotal
+        $this->assertEquals(182.49,$this->cart->getTotal());
+    }
+
     public function test_total_without_condition()
     {
         $this->fillCart();
@@ -61,7 +82,7 @@ class CartConditionTest extends PHPUnit_Framework_TestCase  {
         $condition = new CartCondition(array(
             'name' => 'VAT 12.5%',
             'type' => 'tax',
-            'target' => 'subtotal',
+            'target' => 'total',
             'value' => '12.5%',
         ));
 
@@ -85,13 +106,13 @@ class CartConditionTest extends PHPUnit_Framework_TestCase  {
         $condition1 = new CartCondition(array(
             'name' => 'VAT 12.5%',
             'type' => 'tax',
-            'target' => 'subtotal',
+            'target' => 'total',
             'value' => '12.5%',
         ));
         $condition2 = new CartCondition(array(
             'name' => 'Express Shipping $15',
             'type' => 'shipping',
-            'target' => 'subtotal',
+            'target' => 'total',
             'value' => '+15',
         ));
 
@@ -116,13 +137,13 @@ class CartConditionTest extends PHPUnit_Framework_TestCase  {
         $condition1 = new CartCondition(array(
             'name' => 'VAT 12.5%',
             'type' => 'tax',
-            'target' => 'subtotal',
+            'target' => 'total',
             'value' => '12.5%',
         ));
         $condition2 = new CartCondition(array(
             'name' => 'Express Shipping $15',
             'type' => 'shipping',
-            'target' => 'subtotal',
+            'target' => 'total',
             'value' => '-15',
         ));
 
@@ -147,13 +168,13 @@ class CartConditionTest extends PHPUnit_Framework_TestCase  {
         $condition1 = new CartCondition(array(
             'name' => 'VAT 12.5%',
             'type' => 'tax',
-            'target' => 'subtotal',
+            'target' => 'total',
             'value' => '-12.5%',
         ));
         $condition2 = new CartCondition(array(
             'name' => 'Express Shipping $15',
             'type' => 'shipping',
-            'target' => 'subtotal',
+            'target' => 'total',
             'value' => '-15',
         ));
 
@@ -178,13 +199,13 @@ class CartConditionTest extends PHPUnit_Framework_TestCase  {
         $condition1 = new CartCondition(array(
             'name' => 'VAT 12.5%',
             'type' => 'tax',
-            'target' => 'subtotal',
+            'target' => 'total',
             'value' => '-12.5%',
         ));
         $condition2 = new CartCondition(array(
             'name' => 'Express Shipping $15',
             'type' => 'shipping',
-            'target' => 'subtotal',
+            'target' => 'total',
             'value' => '-15',
         ));
 
@@ -208,13 +229,13 @@ class CartConditionTest extends PHPUnit_Framework_TestCase  {
         $condition1 = new CartCondition(array(
             'name' => 'COUPON LESS 12.5%',
             'type' => 'tax',
-            'target' => 'subtotal',
+            'target' => 'total',
             'value' => '-12.5%',
         ));
         $condition2 = new CartCondition(array(
             'name' => 'Express Shipping $15',
             'type' => 'shipping',
-            'target' => 'subtotal',
+            'target' => 'total',
             'value' => '+15',
         ));
 
@@ -234,7 +255,6 @@ class CartConditionTest extends PHPUnit_Framework_TestCase  {
         $condition1 = new CartCondition(array(
             'name' => 'SALE 5%',
             'type' => 'tax',
-            'target' => 'item',
             'value' => '-5%',
         ));
 
@@ -258,19 +278,16 @@ class CartConditionTest extends PHPUnit_Framework_TestCase  {
         $itemCondition1 = new CartCondition(array(
             'name' => 'SALE 5%',
             'type' => 'sale',
-            'target' => 'item',
             'value' => '-5%',
         ));
         $itemCondition2 = new CartCondition(array(
             'name' => 'Item Gift Pack 25.00',
             'type' => 'promo',
-            'target' => 'item',
             'value' => '-25',
         ));
         $itemCondition3 = new CartCondition(array(
             'name' => 'MISC',
             'type' => 'misc',
-            'target' => 'item',
             'value' => '+10',
         ));
 
@@ -289,7 +306,7 @@ class CartConditionTest extends PHPUnit_Framework_TestCase  {
         $this->assertEquals(80.00, $this->cart->getSubTotal(), 'Cart subtotal with 1 item should be 80');
     }
 
-    public function test_add_item_with_multiple_item_conditions_with_one_condition_wrong_target()
+    public function test_add_item_with_multiple_item_conditions_with_target_omitted()
     {
         // NOTE:
         // $condition1 and $condition4 should not be included in calculation
@@ -297,30 +314,16 @@ class CartConditionTest extends PHPUnit_Framework_TestCase  {
         // conditions in per-item bases, the condition's target should
         // have a value of item
 
-        $itemCondition1 = new CartCondition(array(
-            'name' => 'SALE 5%',
-            'type' => 'sale',
-            'target' => 'subtotal',
-            'value' => '-5%',
-        )); // --> this should not be included in calculation
         $itemCondition2 = new CartCondition(array(
             'name' => 'Item Gift Pack 25.00',
             'type' => 'promo',
-            'target' => 'item',
             'value' => '-25',
         ));
         $itemCondition3 = new CartCondition(array(
             'name' => 'MISC',
             'type' => 'misc',
-            'target' => 'item',
             'value' => '+10',
         ));
-        $itemCondition4 = new CartCondition(array(
-            'name' => 'MISC 2',
-            'type' => 'misc2',
-            'target' => 'subtotal',
-            'value' => '+10%',
-        ));// --> this should not be included in calculation
 
         $item = array(
             'id' => 456,
@@ -328,7 +331,7 @@ class CartConditionTest extends PHPUnit_Framework_TestCase  {
             'price' => 100,
             'quantity' => 1,
             'attributes' => array(),
-            'conditions' => [$itemCondition1, $itemCondition2, $itemCondition3, $itemCondition4]
+            'conditions' => [$itemCondition2, $itemCondition3]
         );
 
         $this->cart->add($item);
@@ -342,13 +345,11 @@ class CartConditionTest extends PHPUnit_Framework_TestCase  {
         $itemCondition2 = new CartCondition(array(
             'name' => 'Item Gift Pack 25.00',
             'type' => 'promo',
-            'target' => 'item',
             'value' => '-25',
         ));
         $coupon101 = new CartCondition(array(
             'name' => 'COUPON 101',
             'type' => 'coupon',
-            'target' => 'item',
             'value' => '-5%',
         ));
 
@@ -377,7 +378,6 @@ class CartConditionTest extends PHPUnit_Framework_TestCase  {
         $condition = new CartCondition([
             'name' => 'Substract amount but prevent negative value',
             'type' => 'promo',
-            'target' => 'item',
             'value' => '-25',
         ]);
 
@@ -404,13 +404,13 @@ class CartConditionTest extends PHPUnit_Framework_TestCase  {
         $itemCondition1 = new CartCondition(array(
             'name' => 'SALE 5%',
             'type' => 'sale',
-            'target' => 'subtotal',
+            'target' => 'total',
             'value' => '-5%',
         ));
         $itemCondition2 = new CartCondition(array(
             'name' => 'Item Gift Pack 25.00',
             'type' => 'promo',
-            'target' => 'subtotal',
+            'target' => 'total',
             'value' => '-25',
         ));
 
@@ -430,7 +430,7 @@ class CartConditionTest extends PHPUnit_Framework_TestCase  {
         $condition = $this->cart->getCondition($itemCondition1->getName());
 
         $this->assertEquals($condition->getName(), 'SALE 5%');
-        $this->assertEquals($condition->getTarget(), 'subtotal');
+        $this->assertEquals($condition->getTarget(), 'total');
         $this->assertEquals($condition->getType(), 'sale');
         $this->assertEquals($condition->getValue(), '-5%');
     }
@@ -440,13 +440,13 @@ class CartConditionTest extends PHPUnit_Framework_TestCase  {
         $itemCondition1 = new CartCondition(array(
             'name' => 'SALE 5%',
             'type' => 'sale',
-            'target' => 'subtotal',
+            'target' => 'total',
             'value' => '-5%',
         ));
         $itemCondition2 = new CartCondition(array(
             'name' => 'Item Gift Pack 25.00',
             'type' => 'promo',
-            'target' => 'subtotal',
+            'target' => 'total',
             'value' => '-25',
         ));
 
@@ -478,13 +478,11 @@ class CartConditionTest extends PHPUnit_Framework_TestCase  {
         $itemCondition1 = new CartCondition(array(
             'name' => 'SALE 5%',
             'type' => 'sale',
-            'target' => 'item',
             'value' => '-5%',
         ));
         $itemCondition2 = new CartCondition(array(
             'name' => 'Item Gift Pack 25.00',
             'type' => 'promo',
-            'target' => 'item',
             'value' => '-25',
         ));
 
@@ -516,7 +514,6 @@ class CartConditionTest extends PHPUnit_Framework_TestCase  {
         $itemCondition = new CartCondition(array(
             'name' => 'SALE 5%',
             'type' => 'sale',
-            'target' => 'item',
             'value' => '-5%',
         ));
 
@@ -546,13 +543,11 @@ class CartConditionTest extends PHPUnit_Framework_TestCase  {
         $itemCondition1 = new CartCondition(array(
             'name' => 'SALE 5%',
             'type' => 'sale',
-            'target' => 'item',
             'value' => '-5%',
         ));
         $itemCondition2 = new CartCondition(array(
             'name' => 'Item Gift Pack 25.00',
             'type' => 'promo',
-            'target' => 'item',
             'value' => '-25',
         ));
 
@@ -586,13 +581,13 @@ class CartConditionTest extends PHPUnit_Framework_TestCase  {
         $itemCondition1 = new CartCondition(array(
             'name' => 'SALE 5%',
             'type' => 'sale',
-            'target' => 'subtotal',
+            'target' => 'total',
             'value' => '-5%',
         ));
         $itemCondition2 = new CartCondition(array(
             'name' => 'Item Gift Pack 25.00',
             'type' => 'promo',
-            'target' => 'subtotal',
+            'target' => 'total',
             'value' => '-25',
         ));
 
@@ -623,13 +618,13 @@ class CartConditionTest extends PHPUnit_Framework_TestCase  {
         $cartCondition1 = new CartCondition(array(
             'name' => 'SALE 5%',
             'type' => 'sale',
-            'target' => 'subtotal',
+            'target' => 'total',
             'value' => '-5%',
         ));
         $cartCondition2 = new CartCondition(array(
             'name' => 'Item Gift Pack 25.00',
             'type' => 'promo',
-            'target' => 'subtotal',
+            'target' => 'total',
             'value' => '-25',
         ));
 
@@ -666,19 +661,19 @@ class CartConditionTest extends PHPUnit_Framework_TestCase  {
         $cartCondition1 = new CartCondition(array(
             'name' => 'SALE 5%',
             'type' => 'sale',
-            'target' => 'subtotal',
+            'target' => 'total',
             'value' => '-5%',
         ));
         $cartCondition2 = new CartCondition(array(
             'name' => 'Item Gift Pack 25.00',
             'type' => 'promo',
-            'target' => 'subtotal',
+            'target' => 'total',
             'value' => '-25',
         ));
         $cartCondition3 = new CartCondition(array(
             'name' => 'Item Less 8%',
             'type' => 'promo',
-            'target' => 'subtotal',
+            'target' => 'total',
             'value' => '-8%',
         ));
 
@@ -713,19 +708,19 @@ class CartConditionTest extends PHPUnit_Framework_TestCase  {
         $cartCondition1 = new CartCondition(array(
             'name' => 'SALE 5%',
             'type' => 'sale',
-            'target' => 'subtotal',
+            'target' => 'total',
             'value' => '-5%',
         ));
         $cartCondition2 = new CartCondition(array(
             'name' => 'Item Gift Pack 20',
             'type' => 'promo',
-            'target' => 'subtotal',
+            'target' => 'total',
             'value' => '-25',
         ));
         $cartCondition3 = new CartCondition(array(
             'name' => 'Item Less 8%',
             'type' => 'promo',
-            'target' => 'subtotal',
+            'target' => 'total',
             'value' => '-8%',
         ));
 
@@ -752,7 +747,7 @@ class CartConditionTest extends PHPUnit_Framework_TestCase  {
         $cartCondition1 = new CartCondition(array(
             'name' => 'SALE 5%',
             'type' => 'sale',
-            'target' => 'subtotal',
+            'target' => 'total',
             'value' => '-5%'
         ));
 
@@ -783,7 +778,7 @@ class CartConditionTest extends PHPUnit_Framework_TestCase  {
         $cartCondition1 = new CartCondition(array(
             'name' => 'SALE 5%',
             'type' => 'sale',
-            'target' => 'subtotal',
+            'target' => 'total',
             'value' => '-5%',
             'attributes' => array(
                 'description' => 'october fest promo sale',
@@ -825,21 +820,21 @@ class CartConditionTest extends PHPUnit_Framework_TestCase  {
         $cartCondition1 = new CartCondition(array(
             'name' => 'SALE 5%',
             'type' => 'sale',
-            'target' => 'subtotal',
+            'target' => 'total',
             'value' => '-5%',
             'order' => 2
         ));
         $cartCondition2 = new CartCondition(array(
             'name' => 'Item Gift Pack 20',
             'type' => 'promo',
-            'target' => 'subtotal',
+            'target' => 'total',
             'value' => '-25',
             'order' => '3'
         ));
         $cartCondition3 = new CartCondition(array(
             'name' => 'Item Less 8%',
             'type' => 'tax',
-            'target' => 'subtotal',
+            'target' => 'total',
             'value' => '-8%',
             'order' => 'first'
         ));
@@ -857,7 +852,40 @@ class CartConditionTest extends PHPUnit_Framework_TestCase  {
         $this->assertEquals('sale', $conditions->shift()->getType());
         $this->assertEquals('promo', $conditions->shift()->getType());
         $this->assertEquals('tax', $conditions->shift()->getType());
+    }
 
+    public function test_condition_ordering()
+    {
+        $cartCondition1 = new CartCondition(array(
+            'name' => 'TAX',
+            'type' => 'tax',
+            'target' => 'total',
+            'value' => '-8%',
+            'order' => 5
+        ));
+        $cartCondition2 = new CartCondition(array(
+            'name' => 'SALE 5%',
+            'type' => 'sale',
+            'target' => 'total',
+            'value' => '-5%',
+            'order' => 2
+        ));
+        $cartCondition3 = new CartCondition(array(
+            'name' => 'Item Gift Pack 20',
+            'type' => 'promo',
+            'target' => 'total',
+            'value' => '-25',
+            'order' => 1
+        ));
+
+        $this->fillCart();
+
+        $this->cart->condition($cartCondition1);
+        $this->cart->condition($cartCondition2);
+        $this->cart->condition($cartCondition3);
+
+        $this->assertEquals('Item Gift Pack 20',$this->cart->getConditions()->first()->getName());
+        $this->assertEquals('TAX',$this->cart->getConditions()->last()->getName());
     }
 
     protected function fillCart()

--- a/tests/CartTest.php
+++ b/tests/CartTest.php
@@ -11,7 +11,7 @@ use Mockery as m;
 
 require_once __DIR__.'/helpers/SessionMock.php';
 
-class CartTest extends PHPUnit_Framework_TestCase  {
+class CartTest extends PHPUnit\Framework\TestCase  {
 
     /**
      * @var Darryldecode\Cart\Cart
@@ -413,24 +413,27 @@ class CartTest extends PHPUnit_Framework_TestCase  {
         $this->assertEquals(3, $item['quantity'], 'Item quantity of with item ID of 456 should now be reduced to 2');
     }
 
+    /**
+     * @expectedException Darryldecode\Cart\Exceptions\InvalidItemException
+     */
     public function test_should_throw_exception_when_provided_invalid_values_scenario_one()
     {
-        $this->setExpectedException('Darryldecode\Cart\Exceptions\InvalidItemException');
-
         $this->cart->add(455, 'Sample Item', 100.99, 0, array());
     }
 
+    /**
+     * @expectedException Darryldecode\Cart\Exceptions\InvalidItemException
+     */
     public function test_should_throw_exception_when_provided_invalid_values_scenario_two()
     {
-        $this->setExpectedException('Darryldecode\Cart\Exceptions\InvalidItemException');
-
         $this->cart->add('', 'Sample Item', 100.99, 2, array());
     }
 
+    /**
+     * @expectedException Darryldecode\Cart\Exceptions\InvalidItemException
+     */
     public function test_should_throw_exception_when_provided_invalid_values_scenario_three()
     {
-        $this->setExpectedException('Darryldecode\Cart\Exceptions\InvalidItemException');
-
         $this->cart->add(523, '', 100.99, 2, array());
     }
 

--- a/tests/CartTestEvents.php
+++ b/tests/CartTestEvents.php
@@ -11,7 +11,7 @@ use Mockery as m;
 
 require_once __DIR__.'/helpers/SessionMock.php';
 
-class CartTestEvents extends PHPUnit_Framework_TestCase {
+class CartTestEvents extends PHPUnit\Framework\TestCase {
 
     const CART_INSTANCE_NAME = 'shopping';
 
@@ -36,6 +36,8 @@ class CartTestEvents extends PHPUnit_Framework_TestCase {
             'SAMPLESESSIONKEY',
             require(__DIR__.'/helpers/configMock.php')
         );
+
+        $this->assertTrue(true);
     }
 
     public function test_event_cart_adding()
@@ -54,6 +56,8 @@ class CartTestEvents extends PHPUnit_Framework_TestCase {
         );
 
         $cart->add(455, 'Sample Item', 100.99, 2, array());
+
+        $this->assertTrue(true);
     }
 
     public function test_event_cart_adding_multiple_times()
@@ -73,6 +77,8 @@ class CartTestEvents extends PHPUnit_Framework_TestCase {
 
         $cart->add(455, 'Sample Item 1', 100.99, 2, array());
         $cart->add(562, 'Sample Item 2', 100.99, 2, array());
+
+        $this->assertTrue(true);
     }
 
     public function test_event_cart_adding_multiple_times_scenario_two()
@@ -115,6 +121,8 @@ class CartTestEvents extends PHPUnit_Framework_TestCase {
         );
 
         $cart->add($items);
+
+        $this->assertTrue(true);
     }
 
     public function test_event_cart_remove_item()
@@ -161,6 +169,8 @@ class CartTestEvents extends PHPUnit_Framework_TestCase {
         $cart->add($items);
 
         $cart->remove(456);
+
+        $this->assertTrue(true);
     }
 
     public function test_event_cart_clear()
@@ -207,5 +217,7 @@ class CartTestEvents extends PHPUnit_Framework_TestCase {
         $cart->add($items);
 
         $cart->clear();
+
+        $this->assertTrue(true);
     }
 }

--- a/tests/CartTestMultipleInstances.php
+++ b/tests/CartTestMultipleInstances.php
@@ -11,7 +11,7 @@ use Mockery as m;
 
 require_once __DIR__.'/helpers/SessionMock.php';
 
-class CartTestMultipleInstances extends PHPUnit_Framework_TestCase {
+class CartTestMultipleInstances extends PHPUnit\Framework\TestCase {
 
     /**
      * @var Darryldecode\Cart\Cart

--- a/tests/CartTestOtherFormat.php
+++ b/tests/CartTestOtherFormat.php
@@ -11,7 +11,7 @@ use Mockery as m;
 
 require_once __DIR__.'/helpers/SessionMock.php';
 
-class CartTestOtherFormat extends PHPUnit_Framework_TestCase  {
+class CartTestOtherFormat extends PHPUnit\Framework\TestCase  {
 
     /**
      * @var Darryldecode\Cart\Cart

--- a/tests/ItemTest.php
+++ b/tests/ItemTest.php
@@ -12,7 +12,7 @@ use Darryldecode\Cart\CartCondition;
 
 require_once __DIR__.'/helpers/SessionMock.php';
 
-class ItemTest extends PHPUnit_Framework_TestCase
+class ItemTest extends PHPUnit\Framework\TestCase
 {
 
     /**

--- a/tests/ItemTestOtherFormat.php
+++ b/tests/ItemTestOtherFormat.php
@@ -11,7 +11,7 @@ use Mockery as m;
 
 require_once __DIR__.'/helpers/SessionMock.php';
 
-class ItemTestOtherFormat extends PHPUnit_Framework_TestCase
+class ItemTestOtherFormat extends PHPUnit\Framework\TestCase
 {
 
     /**


### PR DESCRIPTION
Improvments
 - updated phpunit to 5.0 (to support atleast php 5.6 in testing)
 - removed php <=5.4 support
 - fix failed tests due to upgrade to phpunit5+
 - documentation improvements

Breaking Change!!
 - Adding conditions can now be targeted to either "subtotal" or "total" See:  https://github.com/darryldecode/laravelshoppingcart#conditions for more detailed explanation.
 - When adding condition on per item bases, 'target' parameter is now not needed or can be omitted.

Upgrade guide from version 3.0 to version 4.0:
 - for conditions that are added to cart bases, change 'target' => 'total'
 - If there are conditions that you customly apply to subtotal, you can now add it as normal cart condition and put target => 'subtotal'
 - conditions that are per item or conditions that are added and applied on per item, you can remove the 'target' => 'item' parameter since this is already removed and not needed.