### PR TITLE
removed php 7.2 travis ci test to avoid build error cause by PHPUnit …

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ php:
   - 5.6
   - 7.0
   - 7.1
-  - 7.2
 
 before_script:
   - travis_retry composer self-update


### PR DESCRIPTION
…framework when testing in 7.2 requires tests to use return type declaration which php 7.0 and below does not support yet. But package still work from 5.6-7.3 .. Only test codes failed due to return type declarations