### PR TITLE
fix issue #170

### DIFF
--- a/src/Darryldecode/Cart/Cart.php
+++ b/src/Darryldecode/Cart/Cart.php
@@ -831,6 +831,6 @@ class Cart
      */
     protected function fireEvent($name, $value = [])
     {
-        return $this->events->fire($this->getInstanceName() . '.' . $name, array_values([$value, $this]));
+        return $this->events->dispatch($this->getInstanceName() . '.' . $name, array_values([$value, $this]));
     }
 }

--- a/tests/CartConditionsTest.php
+++ b/tests/CartConditionsTest.php
@@ -22,7 +22,7 @@ class CartConditionTest extends PHPUnit\Framework\TestCase  {
     public function setUp()
     {
         $events = m::mock('Illuminate\Contracts\Events\Dispatcher');
-        $events->shouldReceive('fire');
+        $events->shouldReceive('dispatch');
 
         $this->cart = new Cart(
             new SessionMock(),

--- a/tests/CartTest.php
+++ b/tests/CartTest.php
@@ -21,7 +21,7 @@ class CartTest extends PHPUnit\Framework\TestCase  {
     public function setUp()
     {
         $events = m::mock('Illuminate\Contracts\Events\Dispatcher');
-        $events->shouldReceive('fire');
+        $events->shouldReceive('dispatch');
 
         $this->cart = new Cart(
             new SessionMock(),

--- a/tests/CartTestEvents.php
+++ b/tests/CartTestEvents.php
@@ -27,7 +27,7 @@ class CartTestEvents extends PHPUnit\Framework\TestCase {
     public function test_event_cart_created()
     {
         $events = m::mock('Illuminate\Contracts\Events\Dispatcher');
-        $events->shouldReceive('fire')->once()->with(self::CART_INSTANCE_NAME.'.created', m::type('array'));
+        $events->shouldReceive('dispatch')->once()->with(self::CART_INSTANCE_NAME.'.created', m::type('array'));
 
         $cart = new Cart(
             new SessionMock(),
@@ -43,9 +43,9 @@ class CartTestEvents extends PHPUnit\Framework\TestCase {
     public function test_event_cart_adding()
     {
         $events = m::mock('Illuminate\Events\Dispatcher');
-        $events->shouldReceive('fire')->once()->with(self::CART_INSTANCE_NAME.'.created', m::type('array'));
-        $events->shouldReceive('fire')->once()->with(self::CART_INSTANCE_NAME.'.adding', m::type('array'));
-        $events->shouldReceive('fire')->once()->with(self::CART_INSTANCE_NAME.'.added', m::type('array'));
+        $events->shouldReceive('dispatch')->once()->with(self::CART_INSTANCE_NAME.'.created', m::type('array'));
+        $events->shouldReceive('dispatch')->once()->with(self::CART_INSTANCE_NAME.'.adding', m::type('array'));
+        $events->shouldReceive('dispatch')->once()->with(self::CART_INSTANCE_NAME.'.added', m::type('array'));
 
         $cart = new Cart(
             new SessionMock(),
@@ -63,9 +63,9 @@ class CartTestEvents extends PHPUnit\Framework\TestCase {
     public function test_event_cart_adding_multiple_times()
     {
         $events = m::mock('Illuminate\Events\Dispatcher');
-        $events->shouldReceive('fire')->once()->with(self::CART_INSTANCE_NAME.'.created', m::type('array'));
-        $events->shouldReceive('fire')->times(2)->with(self::CART_INSTANCE_NAME.'.adding', m::type('array'));
-        $events->shouldReceive('fire')->times(2)->with(self::CART_INSTANCE_NAME.'.added', m::type('array'));
+        $events->shouldReceive('dispatch')->once()->with(self::CART_INSTANCE_NAME.'.created', m::type('array'));
+        $events->shouldReceive('dispatch')->times(2)->with(self::CART_INSTANCE_NAME.'.adding', m::type('array'));
+        $events->shouldReceive('dispatch')->times(2)->with(self::CART_INSTANCE_NAME.'.added', m::type('array'));
 
         $cart = new Cart(
             new SessionMock(),
@@ -84,9 +84,9 @@ class CartTestEvents extends PHPUnit\Framework\TestCase {
     public function test_event_cart_adding_multiple_times_scenario_two()
     {
         $events = m::mock('Illuminate\Events\Dispatcher');
-        $events->shouldReceive('fire')->once()->with(self::CART_INSTANCE_NAME.'.created', m::type('array'));
-        $events->shouldReceive('fire')->times(3)->with(self::CART_INSTANCE_NAME.'.adding', m::type('array'));
-        $events->shouldReceive('fire')->times(3)->with(self::CART_INSTANCE_NAME.'.added', m::type('array'));
+        $events->shouldReceive('dispatch')->once()->with(self::CART_INSTANCE_NAME.'.created', m::type('array'));
+        $events->shouldReceive('dispatch')->times(3)->with(self::CART_INSTANCE_NAME.'.adding', m::type('array'));
+        $events->shouldReceive('dispatch')->times(3)->with(self::CART_INSTANCE_NAME.'.added', m::type('array'));
 
         $items = array(
             array(
@@ -128,11 +128,11 @@ class CartTestEvents extends PHPUnit\Framework\TestCase {
     public function test_event_cart_remove_item()
     {
         $events = m::mock('Illuminate\Events\Dispatcher');
-        $events->shouldReceive('fire')->once()->with(self::CART_INSTANCE_NAME.'.created', m::type('array'));
-        $events->shouldReceive('fire')->times(3)->with(self::CART_INSTANCE_NAME.'.adding', m::type('array'));
-        $events->shouldReceive('fire')->times(3)->with(self::CART_INSTANCE_NAME.'.added', m::type('array'));
-        $events->shouldReceive('fire')->times(1)->with(self::CART_INSTANCE_NAME.'.removing', m::type('array'));
-        $events->shouldReceive('fire')->times(1)->with(self::CART_INSTANCE_NAME.'.removed', m::type('array'));
+        $events->shouldReceive('dispatch')->once()->with(self::CART_INSTANCE_NAME.'.created', m::type('array'));
+        $events->shouldReceive('dispatch')->times(3)->with(self::CART_INSTANCE_NAME.'.adding', m::type('array'));
+        $events->shouldReceive('dispatch')->times(3)->with(self::CART_INSTANCE_NAME.'.added', m::type('array'));
+        $events->shouldReceive('dispatch')->times(1)->with(self::CART_INSTANCE_NAME.'.removing', m::type('array'));
+        $events->shouldReceive('dispatch')->times(1)->with(self::CART_INSTANCE_NAME.'.removed', m::type('array'));
 
         $items = array(
             array(
@@ -176,11 +176,11 @@ class CartTestEvents extends PHPUnit\Framework\TestCase {
     public function test_event_cart_clear()
     {
         $events = m::mock('Illuminate\Events\Dispatcher');
-        $events->shouldReceive('fire')->once()->with(self::CART_INSTANCE_NAME.'.created', m::type('array'));
-        $events->shouldReceive('fire')->times(3)->with(self::CART_INSTANCE_NAME.'.adding', m::type('array'));
-        $events->shouldReceive('fire')->times(3)->with(self::CART_INSTANCE_NAME.'.added', m::type('array'));
-        $events->shouldReceive('fire')->once()->with(self::CART_INSTANCE_NAME.'.clearing', m::type('array'));
-        $events->shouldReceive('fire')->once()->with(self::CART_INSTANCE_NAME.'.cleared', m::type('array'));
+        $events->shouldReceive('dispatch')->once()->with(self::CART_INSTANCE_NAME.'.created', m::type('array'));
+        $events->shouldReceive('dispatch')->times(3)->with(self::CART_INSTANCE_NAME.'.adding', m::type('array'));
+        $events->shouldReceive('dispatch')->times(3)->with(self::CART_INSTANCE_NAME.'.added', m::type('array'));
+        $events->shouldReceive('dispatch')->once()->with(self::CART_INSTANCE_NAME.'.clearing', m::type('array'));
+        $events->shouldReceive('dispatch')->once()->with(self::CART_INSTANCE_NAME.'.cleared', m::type('array'));
 
         $items = array(
             array(

--- a/tests/CartTestMultipleInstances.php
+++ b/tests/CartTestMultipleInstances.php
@@ -26,7 +26,7 @@ class CartTestMultipleInstances extends PHPUnit\Framework\TestCase {
     public function setUp()
     {
         $events = m::mock('Illuminate\Contracts\Events\Dispatcher');
-        $events->shouldReceive('fire');
+        $events->shouldReceive('dispatch');
 
         $this->cart1 = new Cart(
             new SessionMock(),

--- a/tests/CartTestOtherFormat.php
+++ b/tests/CartTestOtherFormat.php
@@ -21,7 +21,7 @@ class CartTestOtherFormat extends PHPUnit\Framework\TestCase  {
     public function setUp()
     {
         $events = m::mock('Illuminate\Contracts\Events\Dispatcher');
-        $events->shouldReceive('fire');
+        $events->shouldReceive('dispatch');
 
         $this->cart = new Cart(
             new SessionMock(),

--- a/tests/ItemTest.php
+++ b/tests/ItemTest.php
@@ -23,7 +23,7 @@ class ItemTest extends PHPUnit\Framework\TestCase
     public function setUp()
     {
         $events = m::mock('Illuminate\Contracts\Events\Dispatcher');
-        $events->shouldReceive('fire');
+        $events->shouldReceive('dispatch');
 
         $this->cart = new Cart(
             new SessionMock(),

--- a/tests/ItemTestOtherFormat.php
+++ b/tests/ItemTestOtherFormat.php
@@ -22,7 +22,7 @@ class ItemTestOtherFormat extends PHPUnit\Framework\TestCase
     public function setUp()
     {
         $events = m::mock('Illuminate\Contracts\Events\Dispatcher');
-        $events->shouldReceive('fire');
+        $events->shouldReceive('dispatch');
 
         $this->cart = new Cart(
             new SessionMock(),


### PR DESCRIPTION
Fix for issue #170 cause of fire() method completely removed on laravel 5.8 from being deprecated since 5.5~