### PR TITLE
[BUG FIX] - Prevent cart from breaking if item is an array or null.

### DIFF
--- a/src/Darryldecode/Cart/Cart.php
+++ b/src/Darryldecode/Cart/Cart.php
@@ -672,7 +672,9 @@ class Cart
      */
     public function getContent()
     {
-        return (new CartCollection($this->session->get($this->sessionKeyCartItems)));
+        return (new CartCollection($this->session->get($this->sessionKeyCartItems)))->reject(function($item) {
+            return ! ($item instanceof ItemCollection);
+        });
     }
 
     /**
@@ -682,9 +684,7 @@ class Cart
      */
     public function isEmpty()
     {
-        $cart = new CartCollection($this->session->get($this->sessionKeyCartItems));
-
-        return $cart->isEmpty();
+        return $this->getContent()->isEmpty();
     }
 
     /**


### PR DESCRIPTION
Hey,
This is my first time to contribute to this amazing package. 
Thank you for making this piece of ART!

I encountered a weird bug after checking laravel log file. after digging deeper. I finally succeed to reproduce it.

```
[2020-05-05 18:14:54] local.ERROR: Argument 1 passed to Darryldecode\Cart\Cart::Darryldecode\Cart\{closure}() must be an instance of Darryldecode\Cart\ItemCollection, array given, called in /Users/norredine/code/test-project/vendor/laravel/framework/src/Illuminate/Support/Traits/EnumeratesValues.php on line 424 {"exception":"[object] (TypeError(code: 0): Argument 1 passed to Darryldecode\\Cart\\Cart::Darryldecode\\Cart\\{closure}() must be an instance of Darryldecode\\Cart\\ItemCollection, array given, called in /Users/norredine/code/test-project/vendor/laravel/framework/src/Illuminate/Support/Traits/EnumeratesValues.php on line 424 at /Users/norredine/code/test-project/vendor/darryldecode/cart/src/Darryldecode/Cart/Cart.php:581)
[stacktrace]
```
### Steps to reproduce, 
Delete an item from cart, then update quantity for the same cart item id.
Thank you.