### PR TITLE
Solved problem while two percentage condition.

### DIFF
--- a/src/Darryldecode/Cart/Cart.php
+++ b/src/Darryldecode/Cart/Cart.php
@@ -620,9 +620,7 @@ class Cart
     {
         $subTotal = $this->getSubTotal(false);
 
-        $newTotal = 0.00;
-
-        $process = 0;
+        $conditionTotal = 0.00;
 
         $conditions = $this
             ->getConditions()
@@ -636,15 +634,11 @@ class Cart
         }
 
         $conditions
-            ->each(function (CartCondition $cond) use ($subTotal, &$newTotal, &$process) {
-                $toBeCalculated = ($process > 0) ? $newTotal : $subTotal;
-
-                $newTotal = $cond->applyCondition($toBeCalculated);
-
-                $process++;
+            ->each(function (CartCondition $cond) use ($subTotal, &$conditionTotal) {
+                $conditionTotal = $cond->applyCondition($subTotal);
             });
 
-        return Helpers::formatValue($newTotal, $this->config['format_numbers'], $this->config);
+        return Helpers::formatValue($subTotal+$conditionTotal, $this->config['format_numbers'], $this->config);
     }
 
     /**


### PR DESCRIPTION
I just updated getTotal() method.
I have a problem while added two percentage conditions. Ex.
One for tax
```
$condition1 = new \Darryldecode\Cart\CartCondition(array(
	'name' => 'GST',
	'type' => 'GST',
	'target' => 'total',
	'value' => '5%',
	'attributes' => array( // attributes field is optional
		'description' => 'Value added tax'
	)
));
```
And another one for coupon
```
$condition2 = new \Darryldecode\Cart\CartCondition(array(
	'name' => 'COUPON',
	'type' => 'COUPON',
	'target' => 'total',
	'value' => '-10%',
	'attributes' => array( // attributes field is optional
		'description' => 'Value added tax'
	)
));
```
Applying these two conditions, the result is very strange.
I think it's work in my pull request. 
and I hope it doesn't affect other results.