### PR TITLE
Evol to permit 2 decimals quanity (Crypto currency purposes)

### DIFF
--- a/src/Darryldecode/Cart/Cart.php
+++ b/src/Darryldecode/Cart/Cart.php
@@ -699,7 +699,7 @@ class Cart
         $rules = array(
             'id' => 'required',
             'price' => 'required|numeric',
-            'quantity' => 'required|numeric|min:0.1',
+            'quantity' => 'required|numeric|min:0.01',
             'name' => 'required',
         );
 


### PR DESCRIPTION
For crypto currencies purposes, we need to add to cart products with 2 decimals.