### PR TITLE
Draft: added cached content and cached conditions to improve performance

### DIFF
--- a/src/Darryldecode/Cart/Cart.php
+++ b/src/Darryldecode/Cart/Cart.php
@@ -69,6 +69,10 @@ class Cart
      */
     protected $currentItemId;
 
+    protected $cachedContent = null;
+
+    protected $cachedConditions = null;
+
     /**
      * our object constructor
      *
@@ -397,7 +401,11 @@ class Cart
      */
     public function getConditions()
     {
-        return new CartConditionCollection($this->session->get($this->sessionKeyCartConditions));
+        if(!$this->cachedConditions) {
+            $this->cachedConditions = new CartConditionCollection($this->session->get($this->sessionKeyCartConditions));
+        }
+
+        return $this->cachedConditions;
     }
 
     /**
@@ -672,9 +680,12 @@ class Cart
      */
     public function getContent()
     {
-        return (new CartCollection($this->session->get($this->sessionKeyCartItems)))->reject(function($item) {
-            return ! ($item instanceof ItemCollection);
-        });
+        if(!$this->cachedContent){
+            $this->cachedContent = (new CartCollection($this->session->get($this->sessionKeyCartItems)))->reject(function ($item) {
+                return ! ($item instanceof ItemCollection);
+            });
+        }
+        return $this->cachedContent;
     }
 
     /**


### PR DESCRIPTION
Problem: If you using database storage, getContent or getConditions methods always runs query to get data from database. For example if you call getTotal and getSubTotal methods they call getContent method twice and this will runs 2 same query on database.

Solution: define cachedContent and cachedConditions variable in Cart.php 