### PR TITLE
Fix "deprecated" warning in php 8.2+ (incorrect variable name)

### DIFF
--- a/src/Darryldecode/Cart/Cart.php
+++ b/src/Darryldecode/Cart/Cart.php
@@ -87,7 +87,7 @@ class Cart
         $this->sessionKeyCartItems = $this->sessionKey . '_cart_items';
         $this->sessionKeyCartConditions = $this->sessionKey . '_cart_conditions';
         $this->config = $config;
-        $this->currentItem = null;
+        $this->currentItemId = null;
         $this->fireEvent('created');
     }
 


### PR DESCRIPTION
PHP 8.2+ throws a warning ""DEPRECATED  CDreation of dynamic property ..." on line 90 of Cart.php because the constructor is trying to initialize "currentItem" as opposed to "currentItemId".  A careful study of all the code shows that "currentItem" is not referenced anywhere and so it would appear to be an incorrect variable name.  The enclosed patch initializes the correct variable and eliminates the warning.